### PR TITLE
Expose Data.Deriving.Internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next [????.??.??]
 * Fix a bug in which `deriveEnum`/`deriveIx` would generate ill-scoped code
   for certain poly-kinded data types.
+  
+* Exposed `Internal` modules
 
 ### 0.5.2 [2018.09.13]
 * Fix a bug (on GHC 8.7 and above) in which `deriveGND`/`deriveVia` would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Fix a bug in which `deriveEnum`/`deriveIx` would generate ill-scoped code
   for certain poly-kinded data types.
   
-* Exposed `Internal` modules
+* Expose `Internal` modules
 
 ### 0.5.2 [2018.09.13]
 * Fix a bug (on GHC 8.7 and above) in which `deriveGND`/`deriveVia` would

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -98,28 +98,26 @@ library
                        Data.Deriving.Internal
 
                        Data.Bounded.Deriving
+                       Data.Bounded.Deriving.Internal
                        Data.Deriving.Via
+                       Data.Deriving.Via.Internal
                        Data.Enum.Deriving
+                       Data.Enum.Deriving.Internal
                        Data.Eq.Deriving
+                       Data.Eq.Deriving.Internal
                        Data.Foldable.Deriving
+                       Data.Functor.Deriving.Internal
                        Data.Functor.Deriving
                        Data.Ix.Deriving
+                       Data.Ix.Deriving.Internal
                        Data.Ord.Deriving
+                       Data.Ord.Deriving.Internal
                        Data.Traversable.Deriving
                        Text.Read.Deriving
-                       Text.Show.Deriving
-
-  other-modules:       Data.Bounded.Deriving.Internal
-                       Data.Deriving.Via.Internal
-                       Data.Enum.Deriving.Internal
-                       Data.Eq.Deriving.Internal
-                       Data.Functor.Deriving.Internal
-                       Data.Ix.Deriving.Internal
-                       Data.Ord.Deriving.Internal
                        Text.Read.Deriving.Internal
+                       Text.Show.Deriving
                        Text.Show.Deriving.Internal
-
-                       Paths_deriving_compat
+  other-modules:       Paths_deriving_compat
   build-depends:       containers          >= 0.1   && < 0.7
                      , ghc-prim
                      , th-abstraction      >= 0.2.9 && < 0.3

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -95,6 +95,7 @@ flag new-functor-classes
 
 library
   exposed-modules:     Data.Deriving
+                       Data.Deriving.Internal
 
                        Data.Bounded.Deriving
                        Data.Deriving.Via
@@ -108,9 +109,7 @@ library
                        Text.Read.Deriving
                        Text.Show.Deriving
 
-  other-modules:       Data.Deriving.Internal
-
-                       Data.Bounded.Deriving.Internal
+  other-modules:       Data.Bounded.Deriving.Internal
                        Data.Deriving.Via.Internal
                        Data.Enum.Deriving.Internal
                        Data.Eq.Deriving.Internal

--- a/src/Data/Bounded/Deriving/Internal.hs
+++ b/src/Data/Bounded/Deriving/Internal.hs
@@ -8,6 +8,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Bounded' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Bounded.Deriving.Internal (
       -- * 'Bounded'

--- a/src/Data/Deriving/Internal.hs
+++ b/src/Data/Deriving/Internal.hs
@@ -19,6 +19,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Template Haskell-related utilities.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Deriving.Internal where
 

--- a/src/Data/Deriving/Via/Internal.hs
+++ b/src/Data/Deriving/Via/Internal.hs
@@ -13,6 +13,9 @@ exports functionality which emulates the @GeneralizedNewtypeDeriving@ and
 
 On older versions of @template-haskell@/GHC, this module does not export
 anything.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Deriving.Via.Internal where
 

--- a/src/Data/Enum/Deriving/Internal.hs
+++ b/src/Data/Enum/Deriving/Internal.hs
@@ -6,6 +6,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Enum' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Enum.Deriving.Internal (
       -- * 'Enum'

--- a/src/Data/Eq/Deriving/Internal.hs
+++ b/src/Data/Eq/Deriving/Internal.hs
@@ -9,6 +9,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Eq', 'Eq1', and 'Eq2' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Eq.Deriving.Internal (
       -- * 'Eq'

--- a/src/Data/Functor/Deriving/Internal.hs
+++ b/src/Data/Functor/Deriving/Internal.hs
@@ -11,6 +11,9 @@ The machinery needed to derive 'Foldable', 'Functor', and 'Traversable' instance
 
 For more info on how deriving @Functor@ works, see
 <https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/DeriveFunctor this GHC wiki page>.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Functor.Deriving.Internal (
       -- * 'Foldable'

--- a/src/Data/Ix/Deriving/Internal.hs
+++ b/src/Data/Ix/Deriving/Internal.hs
@@ -6,6 +6,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Ix' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Ix.Deriving.Internal (
       -- * 'Ix'

--- a/src/Data/Ord/Deriving/Internal.hs
+++ b/src/Data/Ord/Deriving/Internal.hs
@@ -9,6 +9,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Ord', 'Ord1', and 'Ord2' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Data.Ord.Deriving.Internal (
       -- * 'Ord'

--- a/src/Text/Read/Deriving/Internal.hs
+++ b/src/Text/Read/Deriving/Internal.hs
@@ -8,6 +8,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Read', 'Read1', and 'Read2' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Text.Read.Deriving.Internal (
       -- * 'Read'

--- a/src/Text/Show/Deriving/Internal.hs
+++ b/src/Text/Show/Deriving/Internal.hs
@@ -8,6 +8,9 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Show', 'Show1', and 'Show2' instances.
+
+Note: this is an internal module, and as such, the API presented here is not
+guaranteed to be stable, even between minor releases of this library.
 -}
 module Text.Show.Deriving.Internal (
       -- * 'Show'


### PR DESCRIPTION
`deriving-compat` doesn't allow you to dump slices and paste them into your code, because the TH definitions use hidden functions. Template Haskell breaks my project, so dumping splices is the only way I can use this library.