### PR TITLE
Fix #27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### next [????.??.??]
+* Permit `deriveVia` to use "floating" `via` type variables, such as the `a`
+  in:
+
+  ```hs
+  deriveVia [t| forall a. Show MyInt `Via` Const Int a |]
+  ```
+
 ### 0.5.6 [2019.05.02]
 * Support deriving `Eq`, `Ord`, and `Show` instances for data types with fields
   of type `Int8#`, `Int16#`, `Word8#`, or `Word16#` on GHC 8.8 or later.

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -158,6 +158,7 @@ test-suite spec
                        ShowSpec
                        GH6Spec
                        GH24Spec
+                       GH27Spec
 
                        Types.EqOrd
                        Types.ReadShow

--- a/src/Data/Deriving.hs
+++ b/src/Data/Deriving.hs
@@ -79,25 +79,25 @@ The following changes have been backported:
 * In GHC 8.4, deriving 'Functor' and 'Traverable' was changed so that it uses 'coerce'
   for efficiency when the last parameter of the data type is at phantom role.
 
-* In GHC 8.4, the `EmptyDataDeriving` proposal brought forth a slew of changes related
+* In GHC 8.4, the @EmptyDataDeriving@ proposal brought forth a slew of changes related
   to how instances for empty data types (i.e., no constructors) were derived. These
   changes include:
 
-    * For derived `Eq` and `Ord` instances for empty data types, simply return
-      `True` and `EQ`, respectively, without inspecting the arguments.
+    * For derived 'Eq' and 'Ord' instances for empty data types, simply return
+      'True' and 'EQ', respectively, without inspecting the arguments.
 
-    * For derived `Read` instances for empty data types, simply return `pfail`
-      (without `parens`).
+    * For derived 'Read' instances for empty data types, simply return 'pfail'
+      (without 'parens').
 
-    * For derived `Show` instances for empty data types, inspect the argument
-      (instead of `error`ing).
+    * For derived 'Show' instances for empty data types, inspect the argument
+      (instead of 'error'ing).
 
-    * For derived `Functor` and `Traversable` instances for empty data
-      types, make `fmap` and `traverse` strict in its argument.
+    * For derived 'Functor' and 'Traversable' instances for empty data
+      types, make 'fmap' and 'traverse' strict in its argument.
 
-    * For derived `Foldable` instances, do not error on empty data types.
-      Instead, simply return the folded state (for `foldr`) or `mempty` (for
-      `foldMap`), without inspecting the arguments.
+    * For derived 'Foldable' instances, do not error on empty data types.
+      Instead, simply return the folded state (for 'foldr') or 'mempty' (for
+      'foldMap'), without inspecting the arguments.
 
 * In GHC 8.6, the @DerivingVia@ language extension was introduced.
   @deriving-compat@ provides an interface which attempts to mimic this
@@ -107,8 +107,11 @@ The following changes have been backported:
   Since the generated code requires the use of @TypeApplications@, this can
   only be backported back to GHC 8.2.
 
-* In GHC 8.6, deriving `Read` was changed so as to factor out certain commonly
+* In GHC 8.6, deriving 'Read' was changed so as to factor out certain commonly
   used subexpressions, which significantly improve compliation times.
+
+* In GHC 8.10, @DerivingVia@ permits \"floating\" type variables in @via@ types,
+  such as the @a@ in @'deriveVia' [t| forall a. Show MyInt ``Via`` Const Int a |]@.
 -}
 
 {- $derive

--- a/tests/GH27Spec.hs
+++ b/tests/GH27Spec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-foralls #-} -- Due to GHC #13512. Sigh.
+#endif
+
+{-|
+Module:      GH27Spec
+Copyright:   (C) 2019 Ryan Scott
+License:     BSD-style (see the file LICENSE)
+Maintainer:  Ryan Scott
+Portability: Template Haskell
+
+A regression test for
+https://github.com/haskell-compat/deriving-compat/issues/27.
+We isolate this test case from the rest of "DerivingViaSpec" because
+we have to disable @-Wunused-foralls@ due to
+https://gitlab.haskell.org/ghc/ghc/issues/13512, and we would prefer not to
+contaminate the rest of "DerivingViaSpec" with this hack.
+-}
+module GH27Spec where
+
+import Prelude ()
+import Prelude.Compat
+
+import Test.Hspec
+
+#if MIN_VERSION_template_haskell(2,12,0)
+import Data.Deriving.Via
+import Data.Functor.Const
+
+newtype Age = MkAge Int
+$(deriveVia [t| forall a. Show Age `Via` Const Int a |])
+#endif
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = pure ()


### PR DESCRIPTION
`deriveVia` was dropping the explicit `forall`s in its `TypeQ` argument, but there's no real reason we should we do so, since we can simply copy them over to the generated instance. For instance, this:

```hs
newtype MyMaybe a = MkMyMaybe (Maybe a)
$(deriveVia [t| forall a. Eq a => Eq (MyMaybe a) `Via` Maybe a |])
```

Can become this:

```hs
instance forall a. Eq a => Eq (MyMaybe a) where
  (==) = coerce @(Maybe   a -> Maybe   a -> Bool)
                @(MyMaybe a -> MyMaybe a -> Bool)
                (==)
```

Even more importantly, doing this allows `deriveVia` to support `via` types that have "floating" type variables, such as in this example from #27:

```hs
newtype Age = MkAge Int
$(deriveVia [t| forall a. Eq Age `Via` Const Int a |])
```

This now becomes:

```hs
instance forall a. Eq Age where
  (==) = coerce @(Const Int a -> Const Int a -> Bool)
                @(Age         -> Age         -> Boool)
                (==)
```

Without that explicit `forall`, the `a`s in `Const Int a -> Const Int a -> Bool` would not be in scope, so this is critical for correctness.

Fixes #27.