### PR TITLE
Fix #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next [????.??.??]
 * Have `deriveFunctor` and `deriveFoldable` derive implementations of `(<$)`
   and `null`, which GHC starting doing in 8.2 and 8.4, respectively.
+* Fix a bug in which `deriveOrd{,1,2}` could generate incorrect code for data
+  types with a combination of nullary and non-nullary constructors.
 * Fix a bug in which `deriveFunctor` would fail on sufficiently complex uses
   of rank-n types in constructor fields.
 * Fix a bug in which `deriveFunctor` and related functions would needlessly

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -160,16 +160,18 @@ test-suite spec
                        GH6Spec
                        GH24Spec
                        GH27Spec
+                       GH31Spec
 
                        Types.EqOrd
                        Types.ReadShow
-  build-depends:       base-compat         >= 0.8.1 && < 1
-                     , base-orphans        >= 0.5   && < 1
+  build-depends:       base-compat         >= 0.8.1  && < 1
+                     , base-orphans        >= 0.5    && < 1
                      , deriving-compat
                      , hspec               >= 1.8
-                     , QuickCheck          >= 2     && < 3
-                     , tagged              >= 0.7   && < 1
-                     , template-haskell    >= 2.5   && < 2.17
+                     , QuickCheck          >= 2      && < 3
+                     , tagged              >= 0.7    && < 1
+                     , template-haskell    >= 2.5    && < 2.17
+                     , void                >= 0.5.10 && < 1
   build-tool-depends:  hspec-discover:hspec-discover >= 1.8
 
   if flag(base-4-9)

--- a/tests/GH31Spec.hs
+++ b/tests/GH31Spec.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+Module:      GH31Spec
+Copyright:   (C) 2020 Ryan Scott
+License:     BSD-style (see the file LICENSE)
+Maintainer:  Ryan Scott
+Portability: Template Haskell
+
+A regression test for
+https://github.com/haskell-compat/deriving-compat/issues/31.
+-}
+module GH31Spec (main, spec) where
+
+import Data.Deriving (deriveEq1, deriveOrd1)
+import Data.Functor.Classes (compare1)
+import Data.Proxy (Proxy(..))
+import Data.Void (Void)
+
+import OrdSpec (ordSpec)
+
+import Prelude ()
+import Prelude.Compat
+
+import Test.Hspec (Spec, describe, hspec, it, parallel, shouldBe)
+import Test.QuickCheck (Arbitrary(..), oneof)
+
+data T a
+  = A
+  | B Int
+  | C Int
+  | D
+  | E Int
+  | F
+  deriving (Eq, Ord, Show)
+
+deriveEq1 ''T
+deriveOrd1 ''T
+
+instance Arbitrary (T a) where
+  arbitrary = oneof [ pure A
+                    , B <$> arbitrary
+                    , C <$> arbitrary
+                    , pure D
+                    , E <$> arbitrary
+                    , pure F
+                    ]
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = parallel $
+  describe "GH31" $ do
+    ordSpec (Proxy :: Proxy (T Void))
+    it "obeys reflexivity" $
+      let x :: T Void
+          x = E 0
+      in compare1 x x `shouldBe` EQ


### PR DESCRIPTION
`makeOrdFunForCon` was using incorrect data constructor tags for data types that feature a combination of nullary and non-nullary constructors. Ultimately, I only have myself to blame for this mistake, since GHC's `deriving Ord` code does this correctly. I simply goofed up when copying GHC's code!