### PR TITLE
Documentation: `Eq1`, `Ord1`, etc. functionality is not backported from GHC

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210827
+# version: 0.13.20211030
 #
-# REGENDATA ("0.13.20210827",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.13.20211030",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -26,15 +26,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.0.20210821
+          - compiler: ghc-9.2.1
             compilerKind: ghc
-            compilerVersion: 9.2.0.20210821
+            compilerVersion: 9.2.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
-            setup-method: ghcup
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -104,14 +104,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
-            apt-get install -y "$HCNAME" cabal-install-3.4
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -129,20 +133,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.4.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -171,17 +175,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          EOF
-          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -231,9 +224,6 @@ jobs:
           package deriving-compat
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(deriving-compat)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@
   https://tldrlegal.com/license/bsd-3-clause-license-%28revised%29
   "BSD 3-Clause License (Revised)"
 
-Provides Template Haskell functions that mimic deriving extensions that were introduced or modified in recent versions of GHC. Currently, the following typeclasses/extensions are covered:
+`deriving-compat` provides Template Haskell functions that mimic deriving extensions that were introduced or modified in recent versions of GHC. Currently, the following typeclasses/extensions are covered:
 
 * Deriving `Bounded`
 * Deriving `Enum`
 * Deriving `Ix`
-* Deriving `Eq`, `Eq1`, and `Eq2`
-* Deriving `Ord`, `Ord1`, and `Ord2`
-* Deriving `Read`, `Read1`, and `Read2`
-* Deriving `Show`, `Show1`, and `Show2`
+* Deriving `Eq`
+* Deriving `Ord`
+* Deriving `Read`
+* Deriving `Show`
 * `DeriveFoldable`
 * `DeriveFunctor`
 * `DeriveTraversable`
@@ -31,6 +31,8 @@ Provides Template Haskell functions that mimic deriving extensions that were int
 * `DerivingVia` (with GHC 8.2 or later)
 
 See the `Data.Deriving` module for a full list of backported changes.
+
+In addition, `deriving-compat` also provides functionality to derive classes in the `Data.Functor.Classes` module, covering the `Eq{1,2}`, `Ord{1,2}`, `Read{1,2}`, and `Show{1,2}` classes. This is functionality that upstream GHC does not currently have, so strictly speaking, this functionality is outside of the main scope of `deriving-compat`. Nevertheless, the underlying Template Haskell functionality needed to derive `Eq` and friends extends very naturally to `Eq{1,2}` and friends, so this extra functionality is included in `deriving-compat` as a convenience.
 
 Note that some recent GHC typeclasses/extensions are not covered by this package:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   https://tldrlegal.com/license/bsd-3-clause-license-%28revised%29
   "BSD 3-Clause License (Revised)"
 
-`deriving-compat` provides Template Haskell functions that mimic deriving extensions that were introduced or modified in recent versions of GHC. Currently, the following typeclasses/extensions are covered:
+`deriving-compat` provides Template Haskell functions that mimic `deriving` extensions that were introduced or modified in recent versions of GHC. Currently, the following typeclasses/extensions are covered:
 
 * Deriving `Bounded`
 * Deriving `Enum`
@@ -32,7 +32,7 @@
 
 See the `Data.Deriving` module for a full list of backported changes.
 
-In addition, `deriving-compat` also provides functionality to derive classes in the `Data.Functor.Classes` module, covering the `Eq1`, `Eq2`, `Ord1`, `Ord2`, `Read1`, `Read2`, `Show1`, and `Show2` classes. This is functionality that upstream GHC does not currently have, so strictly speaking, this functionality is outside of the main scope of `deriving-compat`. Nevertheless, the underlying Template Haskell functionality needed to derive `Eq` and friends extends very naturally to `Eq1` and friends, so this extra functionality is included in `deriving-compat` as a convenience.
+In addition, `deriving-compat` also provides some additional `deriving` functionality that has not yet been merged into upstream GHC. Aside from the GHC `deriving` extensions mentioned above, `deriving-compat` also permits deriving instances of classes in the `Data.Functor.Classes` module, covering the `Eq1`, `Eq2`, `Ord1`, `Ord2`, `Read1`, `Read2`, `Show1`, and `Show2` classes. This extra functionality is outside of the main scope of `deriving-compat`, as it does not backport extensions that exist in today's GHC. Nevertheless, the underlying Template Haskell machinery needed to derive `Eq` and friends extends very naturally to `Eq1` and friends, so this extra functionality is included in `deriving-compat` as a convenience.
 
 Note that some recent GHC typeclasses/extensions are not covered by this package:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 See the `Data.Deriving` module for a full list of backported changes.
 
-In addition, `deriving-compat` also provides functionality to derive classes in the `Data.Functor.Classes` module, covering the `Eq{1,2}`, `Ord{1,2}`, `Read{1,2}`, and `Show{1,2}` classes. This is functionality that upstream GHC does not currently have, so strictly speaking, this functionality is outside of the main scope of `deriving-compat`. Nevertheless, the underlying Template Haskell functionality needed to derive `Eq` and friends extends very naturally to `Eq{1,2}` and friends, so this extra functionality is included in `deriving-compat` as a convenience.
+In addition, `deriving-compat` also provides functionality to derive classes in the `Data.Functor.Classes` module, covering the `Eq1`, `Eq2`, `Ord1`, `Ord2`, `Read1`, `Read2`, `Show1`, and `Show2` classes. This is functionality that upstream GHC does not currently have, so strictly speaking, this functionality is outside of the main scope of `deriving-compat`. Nevertheless, the underlying Template Haskell functionality needed to derive `Eq` and friends extends very naturally to `Eq1` and friends, so this extra functionality is included in `deriving-compat` as a convenience.
 
 Note that some recent GHC typeclasses/extensions are not covered by this package:
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,4 +2,3 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
-ghcup-jobs:             >=8.10

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -88,7 +88,7 @@ tested-with:         GHC == 7.0.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.1
-                   , GHC == 9.2.*
+                   , GHC == 9.2.1
 cabal-version:       >=1.10
 
 source-repository head

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -34,15 +34,15 @@ description:         @deriving-compat@ provides Template Haskell functions that
                      .
                      In addition, @deriving-compat@ also provides functionality
                      to derive classes in the @Data.Functor.Classes@ module,
-                     covering the @Eq{1,2}@, @Ord{1,2}@, @Read{1,2}@, and
-                     @Show{1,2}@ classes. This is functionality that upstream
-                     GHC does not currently have, so strictly speaking, this
-                     functionality is outside of the main scope of
-                     @deriving-compat@. Nevertheless, the underlying Template
-                     Haskell functionality needed to derive @Eq@ and friends
-                     extends very naturally to @Eq{1,2}@ and friends, so this
-                     extra functionality is included in @deriving-compat@ as a
-                     convenience.
+                     covering the @Eq1@, @Eq2@, @Ord1@, @Ord2@, @Read1@,
+                     @Read2@, @Show1@, and @Show2@ classes. This is
+                     functionality that upstream GHC does not currently have,
+                     so strictly speaking, this functionality is outside of the
+                     main scope of @deriving-compat@. Nevertheless, the
+                     underlying Template Haskell functionality needed to derive
+                     @Eq@ and friends extends very naturally to @Eq1@ and
+                     friends, so this extra functionality is included in
+                     @deriving-compat@ as a convenience.
                      .
                      Note that some recent GHC typeclasses/extensions are not covered by this package:
                      .

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -1,9 +1,10 @@
 name:                deriving-compat
 version:             0.6
 synopsis:            Backports of GHC deriving extensions
-description:         Provides Template Haskell functions that mimic deriving
-                     extensions that were introduced or modified in recent versions
-                     of GHC. Currently, the following typeclasses/extensions are covered:
+description:         @deriving-compat@ provides Template Haskell functions that
+                     mimic deriving extensions that were introduced or modified
+                     in recent versions of GHC. Currently, the following
+                     typeclasses/extensions are covered:
                      .
                      * Deriving @Bounded@
                      .
@@ -11,13 +12,13 @@ description:         Provides Template Haskell functions that mimic deriving
                      .
                      * Deriving @Ix@
                      .
-                     * Deriving @Eq@, @Eq1@, and @Eq2@
+                     * Deriving @Eq@
                      .
-                     * Deriving @Ord@, @Ord1@, and @Ord2@
+                     * Deriving @Ord@
                      .
-                     * Deriving @Read@, @Read1@, and @Read2@
+                     * Deriving @Read@
                      .
-                     * Deriving @Show@, @Show1@, and @Show2@
+                     * Deriving @Show@
                      .
                      * @DeriveFoldable@
                      .
@@ -30,6 +31,18 @@ description:         Provides Template Haskell functions that mimic deriving
                      * @DerivingVia@ (with GHC 8.2 or later)
                      .
                      See the "Data.Deriving" module for a full list of backported changes.
+                     .
+                     In addition, @deriving-compat@ also provides functionality
+                     to derive classes in the @Data.Functor.Classes@ module,
+                     covering the @Eq{1,2}@, @Ord{1,2}@, @Read{1,2}@, and
+                     @Show{1,2}@ classes. This is functionality that upstream
+                     GHC does not currently have, so strictly speaking, this
+                     functionality is outside of the main scope of
+                     @deriving-compat@. Nevertheless, the underlying Template
+                     Haskell functionality needed to derive @Eq@ and friends
+                     extends very naturally to @Eq{1,2}@ and friends, so this
+                     extra functionality is included in @deriving-compat@ as a
+                     convenience.
                      .
                      Note that some recent GHC typeclasses/extensions are not covered by this package:
                      .

--- a/deriving-compat.cabal
+++ b/deriving-compat.cabal
@@ -2,7 +2,7 @@ name:                deriving-compat
 version:             0.6
 synopsis:            Backports of GHC deriving extensions
 description:         @deriving-compat@ provides Template Haskell functions that
-                     mimic deriving extensions that were introduced or modified
+                     mimic @deriving@ extensions that were introduced or modified
                      in recent versions of GHC. Currently, the following
                      typeclasses/extensions are covered:
                      .
@@ -32,17 +32,20 @@ description:         @deriving-compat@ provides Template Haskell functions that
                      .
                      See the "Data.Deriving" module for a full list of backported changes.
                      .
-                     In addition, @deriving-compat@ also provides functionality
-                     to derive classes in the @Data.Functor.Classes@ module,
+                     In addition, @deriving-compat@ also provides some additional
+                     @deriving@ functionality that has not yet been merged into
+                     upstream GHC. Aside from the GHC @deriving@ extensions
+                     mentioned above, @deriving-compat@ also permits deriving
+                     instances of classes in the @Data.Functor.Classes@ module,
                      covering the @Eq1@, @Eq2@, @Ord1@, @Ord2@, @Read1@,
-                     @Read2@, @Show1@, and @Show2@ classes. This is
-                     functionality that upstream GHC does not currently have,
-                     so strictly speaking, this functionality is outside of the
-                     main scope of @deriving-compat@. Nevertheless, the
-                     underlying Template Haskell functionality needed to derive
-                     @Eq@ and friends extends very naturally to @Eq1@ and
-                     friends, so this extra functionality is included in
-                     @deriving-compat@ as a convenience.
+                     @Read2@, @Show1@, and @Show2@ classes. This extra
+                     functionality is outside of the main scope of
+                     @deriving-compat@, as it does not backport extensions that
+                     exist in today's GHC. Nevertheless, the underlying Template
+                     Haskell machinery needed to derive @Eq@ and friends
+                     extends very naturally to @Eq1@ and friends, so this extra
+                     functionality is included in @deriving-compat@ as a
+                     convenience.
                      .
                      Note that some recent GHC typeclasses/extensions are not covered by this package:
                      .

--- a/src/Data/Eq/Deriving.hs
+++ b/src/Data/Eq/Deriving.hs
@@ -7,6 +7,10 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Eq', 'Eq1', and 'Eq2' instances.
+Note that upstream GHC does not have the ability to derive 'Eq1' or 'Eq2'
+instances, but since the functionality to derive 'Eq' extends very naturally
+'Eq1' and 'Eq2', the ability to derive the latter two classes is provided as a
+convenience.
 -}
 module Data.Eq.Deriving (
       -- * 'Eq'

--- a/src/Data/Ord/Deriving.hs
+++ b/src/Data/Ord/Deriving.hs
@@ -7,6 +7,10 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Ord', 'Ord1', and 'Ord2' instances.
+Note that upstream GHC does not have the ability to derive 'Ord1' or 'Ord2'
+instances, but since the functionality to derive 'Ord' extends very naturally
+'Ord1' and 'Ord2', the ability to derive the latter two classes is provided as a
+convenience.
 -}
 module Data.Ord.Deriving (
       -- * 'Ord'

--- a/src/Text/Read/Deriving.hs
+++ b/src/Text/Read/Deriving.hs
@@ -7,6 +7,10 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Read', 'Read1', and 'Read2' instances.
+Note that upstream GHC does not have the ability to derive 'Read1' or 'Read2'
+instances, but since the functionality to derive 'Read' extends very naturally
+'Read1' and 'Read2', the ability to derive the latter two classes is provided as a
+convenience.
 -}
 module Text.Read.Deriving (
       -- * 'Read'

--- a/src/Text/Show/Deriving.hs
+++ b/src/Text/Show/Deriving.hs
@@ -7,6 +7,10 @@ Maintainer:  Ryan Scott
 Portability: Template Haskell
 
 Exports functions to mechanically derive 'Show', 'Show1', and 'Show2' instances.
+Note that upstream GHC does not have the ability to derive 'Show1' or 'Show2'
+instances, but since the functionality to derive 'Show' extends very naturally
+'Show1' and 'Show2', the ability to derive the latter two classes is provided as a
+convenience.
 -}
 module Text.Show.Deriving (
       -- * 'Show'


### PR DESCRIPTION
Previously, we didn't really document why `deriving-compat` includes the ability to derive `Eq1`, `Ord1`, etc. even though upstream GHC cannot derive instances of these classes. This is confusing, so let's make the reasoning clearer in the documentation.

Fixes #35.